### PR TITLE
fix: Remove performance-degrading delays from chat processing

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -115,12 +115,6 @@ export function useChat() {
   const processMessageImmediate = useCallback(
     async (content: string) => {
       debug('processMessageImmediate called with:', content);
-      
-      // If we're in the middle of a project switch, wait for it to complete
-      if (isProjectSwitching) {
-        debug('Waiting for project switch to complete before processing message');
-        await new Promise(resolve => setTimeout(resolve, 300));
-      }
 
       // Check if this is a command
       const parsed = parseCommand(content);
@@ -147,11 +141,7 @@ export function useChat() {
               (parsed.args?.[0] === 'switch' || parsed.args?.[0] === 'set') && 
               result.success) {
             debug('Project switch command executed, triggering context refresh');
-            setIsProjectSwitching(true);
             setProjectSwitchTrigger(prev => prev + 1);
-            // Wait for the project context to be updated
-            await new Promise(resolve => setTimeout(resolve, 200));
-            setIsProjectSwitching(false);
           }
 
           // Special handling for clear command
@@ -409,13 +399,9 @@ export function useChat() {
   }, []);
 
   // Callback to notify of project switch
-  const notifyProjectSwitch = useCallback(async () => {
+  const notifyProjectSwitch = useCallback(() => {
     debug('Project switch notification received');
-    setIsProjectSwitching(true);
     setProjectSwitchTrigger(prev => prev + 1);
-    // Wait for the project context to be updated
-    await new Promise(resolve => setTimeout(resolve, 200));
-    setIsProjectSwitching(false);
   }, []);
 
   return {


### PR DESCRIPTION
## Summary
- Removed all setTimeout delays that were causing severe CLI performance issues
- Reverted performance-impacting changes while keeping other fixes

## Problem
The CLI became extremely slow after adding delays to fix project context switching race conditions. These delays (200-300ms) were making every message processing painfully slow.

## Solution
Removed all the setTimeout delays:
- Removed 300ms delay from `processMessageImmediate`
- Removed 200ms delay from project switch command handling  
- Removed async delay from `notifyProjectSwitch` callback

## Impact
- CLI is now responsive again
- Project context switching race condition will need a different solution (without delays)

## Test Plan
- [x] Verify CLI responds quickly to messages
- [x] Test that basic chat functionality works
- [x] Confirm no performance degradation

🤖 Generated with [Claude Code](https://claude.ai/code)