### PR TITLE
fix: Create agent directories before writing container rule files

### DIFF
--- a/docker/rules/generate-rules.js
+++ b/docker/rules/generate-rules.js
@@ -61,7 +61,14 @@ for (const [agentId, config] of Object.entries(agentsToProcess)) {
   // Also write a version without the warning comment for container use
   // Remove the HTML comment block that starts with "<!--" and ends with "-->"
   const outputWithoutWarning = output.replace(/<!--[\s\S]*?-->\s*/m, '');
-  const containerOutputPath = path.join(__dirname, agentId, config.output_filename);
+  const containerOutputDir = path.join(__dirname, agentId);
+  const containerOutputPath = path.join(containerOutputDir, config.output_filename);
+
+  // Ensure the directory exists
+  if (!fs.existsSync(containerOutputDir)) {
+    fs.mkdirSync(containerOutputDir, { recursive: true });
+  }
+
   fs.writeFileSync(containerOutputPath, outputWithoutWarning, 'utf8');
 
   console.log(`Generated ${outputPath}`);


### PR DESCRIPTION
## Summary

Fixes Docker build failure when generating agent rule files during image build.

## Problem

The generate-rules.js script was trying to write files to docker/rules/{agent}/ subdirectories that didn't exist yet, causing ENOENT errors during Docker builds:

```
Error: ENOENT: no such file or directory, open '/tmp/claude-code/CLAUDE.md'
```

## Solution

- Added fs.mkdirSync() call to create agent subdirectories before writing files
- Uses { recursive: true } option to safely create nested directories

## Testing

```bash
cd docker
docker-compose build --no-cache claude-code aider openai-codex opencode
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)