### PR TITLE
fix: Copy agent rules files in entrypoint scripts

### DIFF
--- a/docker/aider/entrypoint.sh
+++ b/docker/aider/entrypoint.sh
@@ -5,6 +5,12 @@ echo "Starting Aider environment as user: $(whoami)"
 echo "Home directory: $HOME"
 echo "Working directory: $(pwd)"
 
+# Copy agent rules file to workspace if it exists and isn't already there
+if [ -f /tmp/rules/aider/CONVENTIONS.md ] && [ ! -f ~/workspace/CONVENTIONS.md ]; then
+    cp /tmp/rules/aider/CONVENTIONS.md ~/workspace/CONVENTIONS.md
+    echo "Copied agent rules to workspace"
+fi
+
 # Check for API keys
 if [ -z "$OPENAI_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
     echo "Warning: Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is set. Aider will not function properly."

--- a/docker/claude-code/entrypoint.sh
+++ b/docker/claude-code/entrypoint.sh
@@ -5,6 +5,12 @@ echo "Starting Claude Code environment as user: $(whoami)"
 echo "Home directory: $HOME"
 echo "Working directory: $(pwd)"
 
+# Copy agent rules file to workspace if it exists and isn't already there
+if [ -f /tmp/rules/claude-code/CLAUDE.md ] && [ ! -f ~/workspace/CLAUDE.md ]; then
+    cp /tmp/rules/claude-code/CLAUDE.md ~/workspace/CLAUDE.md
+    echo "Copied agent rules to workspace"
+fi
+
 # Check for API key
 if [ -z "$ANTHROPIC_API_KEY" ]; then
     echo "Warning: ANTHROPIC_API_KEY not set. Claude Code features will be limited."

--- a/docker/openai-codex/entrypoint.sh
+++ b/docker/openai-codex/entrypoint.sh
@@ -5,6 +5,12 @@ echo "Starting OpenAI Codex environment as user: $(whoami)"
 echo "Home directory: $HOME"
 echo "Working directory: $(pwd)"
 
+# Copy agent rules file to workspace if it exists and isn't already there
+if [ -f /tmp/rules/openai-codex/AGENT.md ] && [ ! -f ~/workspace/AGENT.md ]; then
+    cp /tmp/rules/openai-codex/AGENT.md ~/workspace/AGENT.md
+    echo "Copied agent rules to workspace"
+fi
+
 # Check for API key
 if [ -z "$OPENAI_API_KEY" ]; then
     echo "Warning: OPENAI_API_KEY not set. OpenAI features will be limited."

--- a/docker/opencode/entrypoint.sh
+++ b/docker/opencode/entrypoint.sh
@@ -5,6 +5,12 @@ echo "Starting OpenCode environment as user: $(whoami)"
 echo "Home directory: $HOME"
 echo "Working directory: $(pwd)"
 
+# Copy agent rules file to workspace if it exists and isn't already there
+if [ -f /tmp/rules/opencode/AGENT.md ] && [ ! -f ~/workspace/AGENT.md ]; then
+    cp /tmp/rules/opencode/AGENT.md ~/workspace/AGENT.md
+    echo "Copied agent rules to workspace"
+fi
+
 # Initialize git config for user if not exists
 if [ ! -f ~/.gitconfig ]; then
     git config --global user.email "opencode@llpm.local"


### PR DESCRIPTION
Fixes rules files not appearing in workspace due to volume mounts overwriting them