### PR TITLE
feat: Add agent lifecycle management tools for REST broker (Issue #98)

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -87,7 +87,11 @@ import {
   cancelJobTool,
   markAgentAuthenticatedTool,
   getAgentConnectCommandTool,
-  scaleAgentClusterTool
+  scaleAgentClusterTool,
+  registerAgentTool,
+  deleteAgentTool,
+  updateAgentTool,
+  triggerAgentVerifyTool
 } from './restBrokerTools';
 import {
   setProjectAgentConfigTool,
@@ -175,6 +179,11 @@ const toolRegistry: ToolRegistry = {
   mark_agent_authenticated: markAgentAuthenticatedTool,
   get_agent_connect_command: getAgentConnectCommandTool,
   scale_agent_cluster: scaleAgentClusterTool,
+  // Agent Lifecycle Tools
+  register_agent: registerAgentTool,
+  delete_agent: deleteAgentTool,
+  update_agent: updateAgentTool,
+  trigger_agent_verify: triggerAgentVerifyTool,
   // Project Agent Configuration
   set_project_agent_config: setProjectAgentConfigTool,
   get_project_agent_config: getProjectAgentConfigTool,

--- a/src/tools/restBrokerTools.test.ts
+++ b/src/tools/restBrokerTools.test.ts
@@ -620,4 +620,124 @@ describe('REST Broker Tools', () => {
       expect(parseResult2.success).toBe(false);
     });
   });
+
+  describe('registerAgentTool', () => {
+    it('should require agentId, name, and type parameters', async () => {
+      const { registerAgentTool } = await import('./restBrokerTools');
+      const validResult = registerAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        name: 'Test Agent',
+        type: 'test-type'
+      });
+      expect(validResult.success).toBe(true);
+
+      const invalidResult = registerAgentTool.parameters.safeParse({});
+      expect(invalidResult.success).toBe(false);
+    });
+
+    it('should accept optional authType, provider, model, host, port, metadata', async () => {
+      const { registerAgentTool } = await import('./restBrokerTools');
+      const validResult = registerAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        name: 'Test Agent',
+        type: 'test-type',
+        authType: 'subscription',
+        provider: 'test-provider',
+        model: 'test-model',
+        host: 'localhost',
+        port: 3000,
+        metadata: { key: 'value' }
+      });
+      expect(validResult.success).toBe(true);
+    });
+
+    it('should validate authType enum values', async () => {
+      const { registerAgentTool } = await import('./restBrokerTools');
+      const validResult = registerAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        name: 'Test Agent',
+        type: 'test-type',
+        authType: 'subscription'
+      });
+      expect(validResult.success).toBe(true);
+
+      const invalidResult = registerAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        name: 'Test Agent',
+        type: 'test-type',
+        authType: 'invalid'
+      });
+      expect(invalidResult.success).toBe(false);
+    });
+  });
+
+  describe('deleteAgentTool', () => {
+    it('should require agentId parameter', async () => {
+      const { deleteAgentTool } = await import('./restBrokerTools');
+      const validResult = deleteAgentTool.parameters.safeParse({ agentId: 'test-agent' });
+      expect(validResult.success).toBe(true);
+
+      const invalidResult = deleteAgentTool.parameters.safeParse({});
+      expect(invalidResult.success).toBe(false);
+    });
+
+    it('should accept optional confirmed parameter', async () => {
+      const { deleteAgentTool } = await import('./restBrokerTools');
+      const validResult = deleteAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        confirmed: true
+      });
+      expect(validResult.success).toBe(true);
+    });
+  });
+
+  describe('updateAgentTool', () => {
+    it('should require agentId parameter', async () => {
+      const { updateAgentTool } = await import('./restBrokerTools');
+      const validResult = updateAgentTool.parameters.safeParse({ agentId: 'test-agent' });
+      expect(validResult.success).toBe(true);
+
+      const invalidResult = updateAgentTool.parameters.safeParse({});
+      expect(invalidResult.success).toBe(false);
+    });
+
+    it('should accept optional status and metadata', async () => {
+      const { updateAgentTool } = await import('./restBrokerTools');
+      const validResult = updateAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        status: 'available',
+        metadata: { key: 'value' }
+      });
+      expect(validResult.success).toBe(true);
+    });
+
+    it('should validate status enum values', async () => {
+      const { updateAgentTool } = await import('./restBrokerTools');
+      const validResult = updateAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        status: 'available'
+      });
+      expect(validResult.success).toBe(true);
+
+      const invalidResult = updateAgentTool.parameters.safeParse({
+        agentId: 'test-agent',
+        status: 'invalid'
+      });
+      expect(invalidResult.success).toBe(false);
+    });
+  });
+
+  describe('triggerAgentVerifyTool', () => {
+    it('should accept optional agentId parameter', async () => {
+      const { triggerAgentVerifyTool } = await import('./restBrokerTools');
+      const validResult = triggerAgentVerifyTool.parameters.safeParse({ agentId: 'test-agent' });
+      expect(validResult.success).toBe(true);
+    });
+
+    it('should work without any parameters (verify all)', async () => {
+      const { triggerAgentVerifyTool } = await import('./restBrokerTools');
+      const validResult = triggerAgentVerifyTool.parameters.safeParse({});
+      expect(validResult.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements agent lifecycle management tools for the REST broker, addressing the missing operations from issue #98. This PR adds four new model-accessible tools that allow the LLM to programmatically manage agent registration, updates, deregistration, and authentication verification.

## Changes

### New Tools Implemented

1. **`register_agent`** - Register new agents programmatically
   - Parameters: agentId, name, type, authType, provider, model, host, port, metadata
   - Supports both subscription and api_key authentication types
   - Returns registration details including LiteLLM passthrough URL for subscription agents

2. **`update_agent`** - Update agent status and metadata via heartbeat
   - Parameters: agentId, status (available/busy/offline), metadata
   - Allows programmatic agent state management

3. **`delete_agent`** - Deregister agents (destructive operation)
   - Parameters: agentId, confirmed
   - Requires explicit confirmation via `requiresConfirmation()` pattern
   - Full audit logging for security

4. **`trigger_agent_verify`** - Trigger authentication verification
   - Parameters: agentId (optional - verifies all if omitted)
   - Returns authentication status and expiry details

### Implementation Details

- **Audit Logging**: All tools use `auditToolCall()` to store invocations as project notes
- **Input Validation**: Comprehensive Zod schemas with descriptive field documentation
- **Error Handling**: Graceful error handling with formatted responses
- **Duration Tracking**: Performance monitoring for all operations
- **Consistent Formatting**: Markdown responses with emojis for better UX

### Testing

- Added 10 new test cases covering all 4 tools
- Tests validate parameter schemas, enum constraints, and optional parameters
- **All 50 tests passing** (40 existing + 10 new)

### Files Changed

- `src/tools/restBrokerTools.ts`: +376 lines (4 new tool implementations)
- `src/tools/restBrokerTools.test.ts`: +120 lines (10 new test cases)
- `src/tools/registry.ts`: +11 lines (tool registration)

## Relation to Issue #98

This PR addresses approximately **60% of issue #98** by implementing the agent lifecycle operations. The remaining 40% (already implemented) includes agent queries, job management, health checks, and cluster scaling.

Closes #98

## Test Results

```
✓ src/tools/restBrokerTools.test.ts (50 tests) 339ms

Test Files  1 passed (1)
     Tests  50 passed (50)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)