### PR TITLE
fix: Add maximum limit validation to /debug command

### DIFF
--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -1,9 +1,12 @@
 import type { Command, CommandResult } from './types';
 import { getRecentDebugLogs, debug } from '../utils/logger';
 
+// Maximum number of debug logs that can be requested (matches logger's MAX_DEBUG_LOGS)
+const MAX_LIMIT = 1000;
+
 export const debugCommand: Command = {
   name: 'debug',
-  description: 'Show the last N debug log lines (default: 10)',
+  description: 'Show the last N debug log lines (default: 10, max: 1000)',
   execute: (args: string[]): CommandResult => {
     debug('Executing /debug command with args:', args);
 
@@ -12,23 +15,32 @@ export const debugCommand: Command = {
       return {
         content: `🐛 Debug Command:
 
-/debug [count] - Show the last N debug log lines (default: 10)
+/debug [count] - Show the last N debug log lines (default: 10, max: ${MAX_LIMIT})
 /debug help - Show this help message
 
 📝 Examples:
 • /debug - Show last 10 debug logs
 • /debug 25 - Show last 25 debug logs
+• /debug 1000 - Show maximum number of debug logs
 
-💡 Debug logs include internal application operations and can help troubleshoot issues.`,
+💡 Debug logs include internal application operations and can help troubleshoot issues.
+💡 The system stores up to ${MAX_LIMIT} debug logs in memory.`,
         success: true
       };
     }
 
     const count = args.length > 0 && args[0] ? parseInt(args[0], 10) : 10;
-    
+
     if (isNaN(count) || count <= 0) {
       return {
         content: `❌ Invalid number: ${args[0] || 'undefined'}. Please provide a positive integer.`,
+        success: false
+      };
+    }
+
+    if (count > MAX_LIMIT) {
+      return {
+        content: `❌ Count exceeds maximum limit of ${MAX_LIMIT}. Please request ${MAX_LIMIT} or fewer logs.`,
         success: false
       };
     }


### PR DESCRIPTION
## Summary

Adds maximum limit validation to the `/debug` command to prevent users from requesting more debug logs than the system stores in memory.

## Problem

The `/debug` command allowed users to request any number of logs (e.g., `/debug 10000`), but the logger only stores up to `MAX_DEBUG_LOGS = 1000` entries in memory. This led to:
- Confusing behavior when users request more logs than available
- No feedback about the actual limit
- No validation of the count parameter's upper bound

## Solution

### Code Changes
- ✅ Added `MAX_LIMIT` constant (1000) matching logger's `MAX_DEBUG_LOGS`
- ✅ Added validation to reject counts exceeding the maximum limit
- ✅ Updated command description: `"Show the last N debug log lines (default: 10, max: 1000)"`
- ✅ Enhanced help text to document the maximum limit and system behavior
- ✅ Clear error message when limit is exceeded

### New Behavior

**Before:**
```bash
/debug 10000
# Would attempt to fetch 10000 logs but only get 1000 with no warning
```

**After:**
```bash
/debug 10000
# Returns: ❌ Count exceeds maximum limit of 1000. Please request 1000 or fewer logs.

/debug 1000
# Works correctly: Shows last 1000 debug logs

/debug 50
# Works correctly: Shows last 50 debug logs
```

## Tests Added (6 new tests)

1. ✅ **Reject counts exceeding maximum limit** - `/debug 10000` returns error
2. ✅ **Accept count equal to maximum limit** - `/debug 1000` succeeds
3. ✅ **Reject count just above maximum limit** - `/debug 1001` returns error
4. ✅ **Show maximum limit in help text** - Help includes "max: 1000"
5. ✅ **Show maximum limit in description** - Description includes "max: 1000"
6. ✅ **Updated existing description test** - Matches new description text

## Test Results

All 16 debug command tests passing:
```
✓ src/commands/debug.test.ts (16 tests) 7ms
  ✓ should have correct name and description
  ✓ should return default 10 logs when no args provided
  ✓ should return specified number of logs
  ✓ should handle empty logs gracefully
  ✓ should handle invalid numeric arguments
  ✓ should handle zero and negative numbers
  ✓ should format timestamps correctly
  ✓ should handle malformed timestamps
  ✓ should handle single log with correct grammar
  ✓ should colorize log output
  ✓ should handle floating point numbers
  ✓ should reject counts exceeding the maximum limit ⭐ NEW
  ✓ should accept count equal to maximum limit ⭐ NEW
  ✓ should reject count just above maximum limit ⭐ NEW
  ✓ should show maximum limit in help text ⭐ NEW
  ✓ should show maximum limit in description ⭐ NEW
```

Full test suite: **516 tests passing**

## Files Changed

- `src/commands/debug.ts` - Added MAX_LIMIT constant and validation
- `src/commands/debug.test.ts` - Added 6 new tests for limit validation

## Impact

- ✅ **User Experience**: Clear, actionable error messages
- ✅ **Documentation**: Help text now documents the limit
- ✅ **Consistency**: Aligns command behavior with logger's memory constraints
- ✅ **No Breaking Changes**: Existing valid usage remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>