### PR TITLE
fix: Update model display when switching models via /model command

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -296,7 +296,7 @@ export const ChatInterface = memo(function ChatInterface({
     loadCurrentProject();
   }, []);
 
-  // Load current model on mount
+  // Load current model on mount and when messages change (to detect model switches)
   useEffect(() => {
     const loadModel = async () => {
       try {
@@ -309,6 +309,22 @@ export const ChatInterface = memo(function ChatInterface({
 
     loadModel();
   }, []);
+
+  // Reload model when a model switch notification is detected
+  useEffect(() => {
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage?.role === 'ui-notification' && lastMessage.content.includes('Switched to')) {
+      const loadModel = async () => {
+        try {
+          const model = await loadCurrentModel();
+          setCurrentModel(model);
+        } catch (error) {
+          console.error('Failed to reload model after switch:', error);
+        }
+      };
+      loadModel();
+    }
+  }, [messages]);
 
   // Handle project selection - memoized to prevent re-creation
   const handleProjectSelect = useCallback(


### PR DESCRIPTION
## Summary
Fixes #158 - Model display in status bar now updates immediately after switching models via `/model` command.

## Problem
When users switched models using `/model switch <provider>/<model>`, the status bar at the bottom of the CLI would continue showing the old model name even though the AI was using the new model for requests.

## Root Cause
The `ChatInterface` component only loaded the current model once on mount. When the model was switched via the `/model` command, the ModelRegistry and persistence were updated correctly, but the React component had no way to know it should re-render with the new model.

## Solution
Added a `useEffect` hook to `ChatInterface.tsx` that:
- Watches the messages array for changes
- Detects when a `ui-notification` message contains "Switched to" text (added by the model command)
- Triggers a reload of the current model from storage
- Updates the status bar display with the new model name

## Changes
- Modified `src/components/ChatInterface.tsx` to add model reload logic when switch is detected

## Testing
Manual testing:
1. Start LLPM CLI
2. Check current model in status bar
3. Run `/model switch <different-model>`
4. Verify status bar updates immediately to show new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)