### PR TITLE
feat: Add Skills System for Context-Aware AI Assistance

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -28,7 +28,8 @@ export function App() {
     triggerModelSelector,
     notifyProjectSwitch,
     isProcessing,
-    queuedMessages
+    queuedMessages,
+    selectedSkills
   } = useChat();
 
   // State to track whether to show all history or just the tail
@@ -74,7 +75,8 @@ export function App() {
     onTriggerModelSelector: triggerModelSelector,
     onProjectSwitch: notifyProjectSwitch,
     isProcessing,
-    queuedMessages
+    queuedMessages,
+    selectedSkills
   });
 }
 

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -32,9 +32,10 @@ interface ChatInterfaceProps {
   onProjectSwitch?: () => Promise<void>;
   isProcessing?: boolean;
   queuedMessages?: Array<QueuedMessage>;
+  selectedSkills?: string[];
 }
 
-const ThinkingIndicator = memo(({ isVisible }: { isVisible: boolean }) => {
+const ThinkingIndicator = memo(({ isVisible, selectedSkills }: { isVisible: boolean; selectedSkills?: string[] }) => {
   if (!isVisible) return null;
 
   return (
@@ -43,6 +44,11 @@ const ThinkingIndicator = memo(({ isVisible }: { isVisible: boolean }) => {
         <Text color="red">
           PM is thinking...
         </Text>
+        {selectedSkills && selectedSkills.length > 0 && (
+          <Text color="cyan" dimColor>
+            {' '}(using skill{selectedSkills.length > 1 ? 's' : ''}: {selectedSkills.join(', ')})
+          </Text>
+        )}
       </Box>
       <RequestLogDisplay />
     </Box>
@@ -274,7 +280,8 @@ export const ChatInterface = memo(function ChatInterface({
   onTriggerModelSelector,
   onProjectSwitch,
   isProcessing = false,
-  queuedMessages = []
+  queuedMessages = [],
+  selectedSkills = []
 }: ChatInterfaceProps) {
   const [currentProject, setCurrentProject] = useState<Project | null>(null);
   const [currentModel, setCurrentModel] = useState<ModelConfig | null>(null);
@@ -457,7 +464,7 @@ export const ChatInterface = memo(function ChatInterface({
         showAllHistory={showAllHistory}
       />
       {/* Thinking indicator outside flex container */}
-      <ThinkingIndicator isVisible={isLoading || isProcessing} />
+      <ThinkingIndicator isVisible={isLoading || isProcessing} selectedSkills={selectedSkills} />
       <Box flexDirection="column">
         {/* Input */}
         {inputComponent}


### PR DESCRIPTION
## Summary

Implements Issue #154: Add a Skills system to LLPM that enables automatic context-aware AI assistance through discoverable, reusable instruction packages.

Skills are markdown files with YAML frontmatter that augment the AI's capabilities for specific tasks. The system automatically selects relevant skills based on user prompts and injects them as assistant messages to provide targeted guidance.

## Key Features

### 🔍 Automatic Skill Discovery
- **Multiple discovery paths**: `~/.llpm/skills/`, `~/.llpm/skills/user/`, `.llpm/skills/`
- **Hot reloading**: Skills are rescanned on startup and when switching projects
- **Source tracking**: Skills are categorized as personal or project-specific

### 🎯 Binary Matching Algorithm
Skills are selected using simple yes/no criteria (no scoring):
1. **Name match**: User message contains the skill name
2. **Tag match**: User message contains any skill tag  
3. **Keyword match**: User message has keyword overlap with description (>3 char words)

Results are sorted alphabetically and limited to `maxSkillsPerPrompt` (default: 3).

### 💬 Assistant Message Injection
Instead of polluting the system prompt, selected skills are injected as an assistant message immediately before the user's current message:

```
[system prompt]
[previous conversation...]
[assistant: "I'll use the following skills as helpful instructions for answering your next question:\n\n<skill content>"]
[user: current message]
```

This approach:
- Keeps skills close to the relevant context
- Maintains clean system prompt separation
- Makes skill usage more visible to the model

### 📊 UI Transparency
The thinking indicator now displays selected skills:
- `"PM is thinking... (using skill: user-story-template)"`
- `"PM is thinking... (using skills: skill1, skill2)"`

### 🎮 CLI Management
```bash
/skills              # List all discovered skills
/skills test         # Show skill matching algorithm in action
/skills enable <name>   # Enable a disabled skill
/skills disable <name>  # Disable a skill
/skills reload       # Rescan skill directories
/skills help         # Show detailed help
```

## Skill File Format

Skills are defined in `SKILL.md` files with YAML frontmatter:

```yaml
---
name: user-story-template
description: "Guide writing well-formed user stories with acceptance criteria"
tags:
  - user-story
  - requirements
  - agile
allowed_tools:
  - github
  - notes
vars:
  projectName: "{{projectName}}"
---

# Skill Content

Your markdown instructions here...
```

**Supported fields:**
- `name` (required): Unique identifier
- `description` (required): What the skill does
- `tags` (optional): Keywords for matching
- `allowed_tools` (optional): Tool restrictions (future feature)
- `vars` (optional): Variable substitution with `{{varName}}` syntax
- `resources` (optional): External resource references

## Architecture

### Core Components

**`src/types/skills.ts`**
- Type definitions for skills, configuration, events

**`src/utils/skillParser.ts`**
- YAML frontmatter parsing with gray-matter
- Schema validation
- Variable substitution

**`src/services/SkillRegistry.ts`**
- Skill lifecycle management (discovery, loading, validation)
- Binary matching logic (`findRelevant()`)
- EventEmitter for telemetry
- Prompt augmentation generation

**`src/commands/skills.ts`**
- CLI command implementation
- Skill inspection and management

**`src/services/llm.ts`**
- Skill selection during message processing
- Assistant message injection
- Returns both response and selected skill names

**`src/hooks/useChat.ts`**
- Manages `selectedSkills` state
- Clears skills before each request
- Threads skills to UI

**`src/components/ChatInterface.tsx`**
- ThinkingIndicator displays active skills
- Visual feedback in cyan dimmed text

### How It Works

1. **On Startup**: SkillRegistry scans configured paths and discovers all `SKILL.md` files
2. **On Project Switch**: Skills are rescanned to pick up project-specific skills
3. **On User Message**: 
   - Extract last user message content
   - Call `skillRegistry.findRelevant({ userMessage })`
   - Binary match against all enabled skills
   - Generate prompt augmentation from matched skills
   - Inject as assistant message before user's current message
   - Emit telemetry events for selected skills
4. **In UI**: ThinkingIndicator displays selected skill names during processing

## Example Skills

**user-story-template** (PM skill)
- Guides writing INVEST-compliant user stories
- Includes acceptance criteria templates
- Tags: user-story, requirements, agile

**stakeholder-updates** (PM skill)
- Communication templates for different audiences
- Tags: communication, stakeholders, reporting

## Testing

**63 tests passing:**
- 19 tests: `SkillRegistry.test.ts` - Binary matching logic
- 11 tests: `skillParser.test.ts` - YAML parsing and validation
- 28 tests: `skills.test.ts` - CLI command integration
- 5 tests: `SkillRegistry.projectSwitch.test.ts` - Discovery and rescanning

All tests verify:
- Name, tag, and description keyword matching
- Alphabetical sorting and limit enforcement
- Variable substitution
- Prompt augmentation formatting
- CLI command behavior
- Project switch handling

## Configuration

Default configuration in `SkillsConfig`:

```typescript
{
  enabled: true,
  maxSkillsPerPrompt: 3,
  paths: ['~/.llpm/skills', '~/.llpm/skills/user', '.llpm/skills'],
  requireConfirmationOnDeniedTool: true
}
```

## Migration Notes

- No breaking changes to existing functionality
- Skills are opt-in (only activate when matched)
- System prompt remains unchanged
- No impact on performance (single scan on startup)

## Future Enhancements

- [ ] Tool restriction enforcement (`allowed_tools`)
- [ ] LLM-based skill selection for complex queries
- [ ] Skill marketplace/sharing
- [ ] Skill analytics (usage tracking, effectiveness metrics)
- [ ] Conditional skill activation (context-based rules)

## Closes

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>