### PR TITLE
perf: Eliminate screen flicker when typing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,9 @@ export function App() {
 
   // Number of recent messages to keep in dynamic zone (rest go to static)
   // Keep this as low as possible to minimize flicker - only streaming/updating messages need to be dynamic
-  const DYNAMIC_MESSAGE_COUNT = 2;
+  // When not loading: 0 messages in dynamic zone = zero flicker when typing
+  // When loading: 1 message in dynamic zone = only the streaming message can update
+  const DYNAMIC_MESSAGE_COUNT = isLoading ? 1 : 0;
 
   // Track messages that have been moved to static zone
   // Static zone NEVER recalculates - only accumulates new messages
@@ -109,7 +111,7 @@ export function App() {
       hiddenLinesCount,
       totalLines
     };
-  }, [messages, showAllHistory, maxRenderedLines, staticMessages]);
+  }, [messages, showAllHistory, maxRenderedLines, staticMessages, isLoading]);
 
   return React.createElement(ChatInterface, {
     completedMessages,


### PR DESCRIPTION
## Summary

Fixes screen flicker that occurred when typing in the CLI input field with large messages visible.

## Problem

When typing in the CLI, the entire screen would flicker on every keystroke if there were large messages displayed. This made the interface feel sluggish and janky, especially during long conversations.

**Root cause**: `DYNAMIC_MESSAGE_COUNT` was fixed at 2, meaning the last 2 messages were always in the re-rendering zone. Every keystroke triggered a full re-render of these messages, causing visible flicker.

## Solution

Made `DYNAMIC_MESSAGE_COUNT` adaptive based on the `isLoading` state:

- **When idle** (not streaming): `DYNAMIC_MESSAGE_COUNT = 0` → All messages move to static zone
- **When streaming**: `DYNAMIC_MESSAGE_COUNT = 1` → Only the actively streaming message remains in dynamic zone

## Why This Works

1. **Ink's `<Static>` component never re-renders** - Once rendered, it's frozen
2. **Completed messages immediately frozen** - As soon as streaming stops, messages move to static zone
3. **Zero overhead** - No complex memoization or wrapper components needed
4. **Clean integration** - Works perfectly with existing two-zone architecture

## Testing

- ✅ Messages load correctly on startup
- ✅ No flicker when typing with large messages visible
- ✅ Streaming messages still update in real-time
- ✅ No React key warnings or errors
- ✅ All existing functionality preserved

## Impact

**Before**: Typing caused visible screen flicker with every keystroke when large messages were displayed

**After**: Zero flicker when typing - completed messages are completely frozen in the static zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)