### PR TITLE
fix(ui): Prevent unconfigured provider model from showing in footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llpm",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Large Language Model Product Manager - AI-powered CLI for software development",
   "keywords": ["llm", "ai", "cli", "product-manager", "development", "tools"],
   "author": "britt",


### PR DESCRIPTION
## Summary

Fixes #176

- Footer was using `loadCurrentModel()` which returns raw stored model without validating provider configuration
- Changed to use `modelRegistry.getCurrentModel()` which validates against configured providers
- Footer and model selector are now consistent - both only show configured providers

## Changes

- `ChatInterface.tsx`: Use `modelRegistry.getCurrentModel()` instead of `loadCurrentModel()`
- `modelRegistry.test.ts`: Added 5 tests for Issue #176 scenarios
- Version bump: 1.0.2 → 1.0.3

## Test plan

- [x] All 1554 tests pass
- [x] New tests verify bug scenario and fix
- [x] No TypeScript errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)