### PR TITLE
fix: Resolve variable shadowing bug in projectScanOrchestrator

### DIFF
--- a/bin/llpm
+++ b/bin/llpm
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Development wrapper - runs LLPM with bun
+cd "$(dirname "$0")/.." && exec bun run index.ts "$@"

--- a/src/services/projectScanOrchestrator.ts
+++ b/src/services/projectScanOrchestrator.ts
@@ -6,7 +6,7 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import packageJson from '../../package.json';
+import llpmPackageJson from '../../package.json';
 import { createIgnoreFilter } from '../utils/gitignore';
 import {
   scanFiles,
@@ -192,7 +192,7 @@ export class ProjectScanOrchestrator {
     const totalLines = files.reduce((sum, f) => sum + (f.lines || 0), 0);
 
     const scan: ProjectScan = {
-      version: packageJson.version,
+      version: llpmPackageJson.version,
       scannedAt: new Date().toISOString(),
       projectId,
       projectName,


### PR DESCRIPTION
## Summary

Fixes an error when running `/project scan` on projects without a package.json file:

```
❌ Failed to analyze project: undefined is not an object (evaluating 'packageJson.version')
```

## Root Cause

The import `packageJson` (for LLPM's version) was being shadowed by a local `packageJson` variable (for the scanned project's package.json). When scanning a project without package.json, the local variable was undefined, causing the error.

## Fix

Renamed the import to `llpmPackageJson` to avoid the naming conflict.

## Test plan
- [x] Tests pass
- [ ] Run `/project scan` on a project without package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)