### PR TITLE
Add bunfig.toml and fix build configuration

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+exact = true
+
+telemetry = false

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "llpm": "./bin/llpm.cjs"
   },
   "scripts": {
-    "build": "bun build index.ts --compile --outfile bin/llpm --alias react-devtools-core=./stubs/react-devtools-core.js",
+    "build": "bun build index.ts --compile --outfile bin/llpm",
     "postinstall": "node scripts/postinstall.cjs",
     "start": "bun run index.ts",
     "start:verbose": "bun run index.ts --verbose",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,10 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "react-devtools-core": ["./stubs/react-devtools-core.js"]
+    },
 
     // Best practices
     "strict": true,


### PR DESCRIPTION
## Summary

- Add `bunfig.toml` with `exact = true` for reproducible installs and `telemetry = false`
- Fix build script by removing invalid `--alias` CLI flag that was causing build failures
- Move `react-devtools-core` aliasing to `tsconfig.json` paths mapping (the correct approach)

## Changes

| File | Change |
|------|--------|
| `bunfig.toml` | New file with install and telemetry config |
| `package.json` | Remove broken `--alias` flag from build script |
| `tsconfig.json` | Add `baseUrl` and `paths` for module aliasing |

## Test plan

- [x] `bun run build` succeeds
- [x] `bun install` respects exact versioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)