### PR TITLE
docs: add Hugo documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.139.0
+      HUGO_VERSION: 0.146.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add comprehensive Hugo-based documentation site using Hextra theme
- Configure GitHub Actions workflow for automated deployment to GitHub Pages
- Document all features: Getting Started, User Guide, Skills Reference, Contributing

## Documentation Structure

- **Getting Started**: Installation, Quickstart, Configuration
- **User Guide**: Commands, Projects, Skills, GitHub Integration
- **Skills Reference**: All 19 core skills documented across 6 categories
- **Contributing**: Development setup, Testing practices

## Deployment

The workflow deploys to GitHub Pages on pushes to `main` that modify `docs/**`.

**Required setup**: Enable GitHub Pages with "GitHub Actions" as the source in repository settings.

## Test plan

- [ ] Verify Hugo builds locally with `cd docs && hugo server`
- [ ] Confirm GitHub Actions workflow succeeds after merge
- [ ] Check documentation renders correctly at https://britt.github.io/llpm/

🤖 Generated with [Claude Code](https://claude.com/claude-code)