### PR TITLE
Configure npm trusted publishing for GitHub Actions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,8 +15,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       - name: Verify version matches release tag
         run: |
@@ -32,6 +35,4 @@ jobs:
         run: npm pack --dry-run
 
       - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Replace NPM_TOKEN with OIDC-based trusted publishing in the npm-publish workflow.

**Changes:**
- Bump Node.js to v24 (ships with npm 11.5.1+)
- Install latest npm before publishing
- Add --provenance flag to npm publish
- Remove NODE_AUTH_TOKEN environment variable

**After Merging:**
Remember to configure the trusted publisher in package settings on npmjs.com once the package is published.