### PR TITLE
ci(vouch): use deploy key for manage workflows to bypass branch protection

### DIFF
--- a/.github/workflows/vouch-manage-by-discussion.yml
+++ b/.github/workflows/vouch-manage-by-discussion.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.VOUCH_DEPLOY_KEY }}
 
       - uses: mitchellh/vouch/action/manage-by-discussion@v1
         with:

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.VOUCH_DEPLOY_KEY }}
 
       - uses: mitchellh/vouch/action/manage-by-issue@v1
         with:


### PR DESCRIPTION
## Summary

Updates the manage-by-issue and manage-by-discussion workflows to use a deploy key for git operations, allowing them to bypass branch protection rules when pushing changes to VOUCHED.td.

## Implementation

The check-issue and check-pr workflows only make API calls and don't need changes. The manage workflows now checkout with `ssh-key: ${{ secrets.VOUCH_DEPLOY_KEY }}`.

## Setup Required

You need to add a deploy key to the repo:
1. Generate: `ssh-keygen -t ed25519 -C "vouch-deploy-key" -f vouch-deploy-key`
2. Add public key (`vouch-deploy-key.pub`) as a deploy key with write access
3. Add private key as repo secret `VOUCH_DEPLOY_KEY`
4. Add "Deploy keys" as a bypass actor in your ruleset

🤖 Generated with Claude Code