### PR TITLE
Enhance npm-publish workflow with RELEASE_TAG input

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,9 @@ name: Publish to NPM
 
 on:
   workflow_dispatch:
+    inputs:
+      RELEASE_TAG: 
+        required: true
   release:
     types: [published]
 


### PR DESCRIPTION
Add input for RELEASE_TAG to workflow dispatch.