### PR TITLE
fix(project): expand ~ in paths for /project add

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,25 @@
 # PROGRESS.md
 
+## Task: Fix tilde expansion in /project add (#254) - COMPLETE
+- Started: 2026-02-14
+- Tests: 2172 passing, 13 skipped
+- Build: Successful (10.51 MB bundle)
+- Linting: Clean in modified files (pre-existing errors elsewhere unchanged)
+- Completed: 2026-02-14
+- Notes:
+  - Added `expandPath()` utility to expand `~` to home directory and resolve relative paths
+  - Applied in `addProject()` so all entry points (CLI, setup wizard, AI tool) get path expansion
+  - Setup wizard now expands path before `checkPathExists` validation
+  - CLI `/project add` response shows expanded path instead of raw input
+  - TDD: 7 new tests written first and verified failing before implementation
+
+### Files Changed
+- `src/utils/projectConfig.ts` - Added `expandPath()`, applied in `addProject()`
+- `src/utils/projectConfig.test.ts` - 7 new tests (4 for expandPath, 2 for addProject expansion, 1 cleanup)
+- `src/commands/project.ts` - Show `newProject.path` (expanded) in success message
+- `src/setup/steps/project.ts` - Expand path before validation
+- `src/setup/steps/project.test.ts` - New test for tilde expansion in setup step
+
 ## Task: Auto-switch to newly created project (#263) - COMPLETE
 - Started: 2026-02-13T15:55:00Z
 - Tests: 2099 passing, 0 failing (full suite)

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -263,7 +263,7 @@ export const projectCommand: Command = {
           };
           const newProject = await addProject(projectData);
           return {
-            content: `✅ Added project "${newProject.name}" (ID: ${newProject.id})\n📂 Repository: ${normalizedRepository}\n📍 Path: ${path}${newProject.description ? `\n📝 Description: ${newProject.description}` : ''}\n🔄 Switched active project to "${newProject.name}"`,
+            content: `✅ Added project "${newProject.name}" (ID: ${newProject.id})\n📂 Repository: ${normalizedRepository}\n📍 Path: ${newProject.path}${newProject.description ? `\n📝 Description: ${newProject.description}` : ''}\n🔄 Switched active project to "${newProject.name}"`,
             success: true
           };
         } catch (error) {

--- a/src/setup/steps/project.ts
+++ b/src/setup/steps/project.ts
@@ -1,6 +1,6 @@
 import { existsSync as fsExistsSync } from 'fs';
 import { askQuestion, askYesNo, type ReadlineInterface } from '../prompts';
-import { addProject, listProjects } from '../../utils/projectConfig';
+import { addProject, listProjects, expandPath } from '../../utils/projectConfig';
 import type { Project } from '../../types/project';
 
 export interface ProjectResult {
@@ -61,11 +61,12 @@ export async function setupFirstProject(
       console.log('  Path is required.');
       continue;
     }
-    if (!deps.checkPathExists(input)) {
+    const expanded = expandPath(input);
+    if (!deps.checkPathExists(expanded)) {
       console.log(`  Path "${input}" does not exist. Please enter a valid path.`);
       continue;
     }
-    path = input;
+    path = expanded;
   }
 
   const descriptionInput = await askQuestion(rl, '  Description (optional): ');


### PR DESCRIPTION
Expands tilde (~) in project paths to the user's home directory before storing and validating.

This ensures paths like `~/projects/my-app` are automatically expanded to absolute paths (e.g., `/Users/username/projects/my-app`), making the CLI more user-friendly.

Closes #254