### PR TITLE
fix(ui): refresh status line after project add/remove (#294)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,27 @@
 # PROGRESS.md
 
+## Task: Fix stale status line after project mutations (#294) - COMPLETE
+- Started: 2026-02-15
+- Tests: 1912 passing, 0 failing (4 new tests added)
+- Build: Successful (10.36 MB bundle)
+- Linting: Clean in modified files
+- Version: 1.8.2 -> 1.8.3 (PATCH - bug fix)
+- Completed: 2026-02-15
+- Notes:
+  - Status line now refreshes when /project add, /project remove, /project switch, or /project set executes
+  - Root cause: ChatInterface loaded currentProject once on mount and never re-read it
+  - Fix: Exposed projectSwitchTrigger from useChat, passed through index.ts to ChatInterface as prop
+  - Added it as dependency on project-loading useEffect so status line re-reads after any project mutation
+  - Expanded trigger condition in useChat to fire for add/remove (was only switch/set)
+  - TDD: 4 tests written first and verified failing before implementation
+
+### Files Changed
+- `src/hooks/useChat.ts` - Expanded trigger condition for add/remove, exposed projectSwitchTrigger
+- `src/hooks/useChat.test.ts` - 4 new tests for trigger exposure and mutation detection
+- `src/components/ChatInterface.tsx` - Accept projectSwitchTrigger prop, use as useEffect dependency
+- `index.ts` - Pass projectSwitchTrigger from useChat to ChatInterface
+- `package.json` - Version bump to 1.8.3
+
 ## Task: Migrate 26 Tools to 5 Skills (#221) - COMPLETE
 - Started: 2026-02-14
 - Tests: 1908 passing, 0 failing

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ export function App() {
     cancelModelSelection,
     triggerModelSelector,
     notifyProjectSwitch,
+    projectSwitchTrigger,
     isProcessing,
     queuedMessages,
     selectedSkills
@@ -129,6 +130,7 @@ export function App() {
     onCancelModelSelection: cancelModelSelection,
     onTriggerModelSelector: triggerModelSelector,
     onProjectSwitch: notifyProjectSwitch,
+    projectSwitchTrigger,
     isProcessing,
     queuedMessages,
     selectedSkills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@britt/llpm",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Large Language Model Product Manager - AI-powered CLI for software development",
   "keywords": [
     "llm",

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -32,6 +32,7 @@ interface ChatInterfaceProps {
   onCancelModelSelection?: () => void;
   onTriggerModelSelector?: () => void;
   onProjectSwitch?: () => Promise<void>;
+  projectSwitchTrigger?: number;
   isProcessing?: boolean;
   queuedMessages?: Array<QueuedMessage>;
   selectedSkills?: string[];
@@ -293,6 +294,7 @@ export const ChatInterface = memo(function ChatInterface({
   onCancelModelSelection,
   onTriggerModelSelector,
   onProjectSwitch,
+  projectSwitchTrigger,
   isProcessing = false,
   queuedMessages = [],
   selectedSkills = []
@@ -301,7 +303,7 @@ export const ChatInterface = memo(function ChatInterface({
   const [currentModel, setCurrentModel] = useState<ModelConfig | null>(null);
   const [activeInput, setActiveInput] = useState<'main' | 'project' | 'model' | 'notes'>('main');
 
-  // Load current project on mount
+  // Load current project on mount and when project mutations occur
   useEffect(() => {
     const loadCurrentProject = async () => {
       try {
@@ -313,7 +315,7 @@ export const ChatInterface = memo(function ChatInterface({
     };
 
     loadCurrentProject();
-  }, []);
+  }, [projectSwitchTrigger]);
 
   // Load current model on mount - uses modelRegistry to ensure model is from a configured provider
   // This fixes Issue #176: prevents showing unconfigured provider models in the footer

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -173,11 +173,12 @@ export function useChat() {
             return;
           }
 
-          // Special handling for project switch command
-          if (parsed.command === 'project' && 
-              (parsed.args?.[0] === 'switch' || parsed.args?.[0] === 'set') && 
+          // Special handling for project mutation commands (switch, set, add, remove)
+          if (parsed.command === 'project' &&
+              (parsed.args?.[0] === 'switch' || parsed.args?.[0] === 'set' ||
+               parsed.args?.[0] === 'add' || parsed.args?.[0] === 'remove') &&
               result.success) {
-            debug('Project switch command executed, triggering context refresh');
+            debug('Project mutation command executed, triggering context refresh');
             setIsProjectSwitching(true);
             setProjectSwitchTrigger(prev => prev + 1);
             // Wait for the project context to be updated
@@ -525,6 +526,7 @@ export function useChat() {
     cancelModelSelection,
     triggerModelSelector,
     notifyProjectSwitch,
+    projectSwitchTrigger,
     // Queue status for UI indicators
     queueLength: messageQueue.length,
     isProcessing,


### PR DESCRIPTION
## Summary

Fixes a bug where the status line displayed stale project information after running `/project add` or `/project remove` commands. The status line would only refresh after `/project switch` or `/project set`.

## Changes

- **src/hooks/useChat.ts**: Expanded project mutation detection to include `add` and `remove` commands, and exposed `projectSwitchTrigger` in the hook's return value
- **src/components/ChatInterface.tsx**: Added `projectSwitchTrigger` prop and wired it as a dependency to the `useEffect` that loads the current project
- **index.ts**: Passed `projectSwitchTrigger` from `useChat` to `ChatInterface`
- **src/hooks/useChat.test.ts**: Added 4 new tests covering trigger exposure and mutation detection
- **package.json**: Bumped version to 1.8.3 (PATCH)

Closes #294